### PR TITLE
Fix duplicate handler in BoardContainer event bus

### DIFF
--- a/src/controllers/BoardContainer.js
+++ b/src/controllers/BoardContainer.js
@@ -78,8 +78,6 @@ class BoardContainer extends Component {
             })
           case 'UPDATE_CARDS':
             return actions.updateCards({laneId: event.laneId, cards: event.cards})
-          case 'UPDATE_CARD':
-            return actions.updateCard({laneId: event.laneId, updatedCard: event.card})
           case 'UPDATE_LANES':
             return actions.updateLanes(event.lanes)
           case 'UPDATE_LANE':


### PR DESCRIPTION
## Summary
- fix event bus handler so UPDATE_CARD is not duplicated

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_683f07b435a4832883c18ac2d0b4fa01